### PR TITLE
Remove www.a-trust.at

### DIFF
--- a/ocsp.txt
+++ b/ocsp.txt
@@ -1003,7 +1003,6 @@
 127.0.0.1 wtocsp-cdn.itrus.com.cn
 127.0.0.1 www3.postsignum.cz
 127.0.0.1 www.anf.es
-127.0.0.1 www.a-trust.at
 127.0.0.1 www.defence.gov.au
 127.0.0.1 www.dir.esecure.datev.de
 127.0.0.1 www.gdca.com.cn


### PR DESCRIPTION
a-trust is used to create and verify signatures of e.g. PDFs. Their OCSP is on the list but the web page should not be.